### PR TITLE
fix: estabiliza fluxo financeiro do MVP

### DIFF
--- a/src/controllers/financeiro.ts
+++ b/src/controllers/financeiro.ts
@@ -2,7 +2,6 @@ import { Response } from "express";
 import { ExtendedRequest } from "../types/extended-request";
 import { z } from "zod";
 import { BadRequest, UnAuthorized } from "../error";
-import material from "../model/material";
 import contaFinanceira from "../model/contaFinanceira";
 import transferenciaFinanceira from "../model/transferencia";
 import caixaFinanceiro from "../model/caixa";
@@ -13,7 +12,7 @@ export const conta = {
       const data = z
         .object({
           nome: z.string().toUpperCase().min(3),
-          saldo_inicial: z.coerce.number().positive(),
+          saldo_inicial: z.coerce.number().nonnegative(),
           conta_padrao: z.boolean().optional(),
         })
         .strict()
@@ -26,7 +25,7 @@ export const conta = {
       const novaConta = await contaFinanceira.create(data.data);
 
       res.status(201).json(novaConta);
-    } catch (error: any) {
+    } catch (error: unknown) {
       throw error;
     }
   },
@@ -46,7 +45,6 @@ export const conta = {
         })
         .strict()
         .safeParse(req.body);
-      console.log(req.body);
       if (!body.success || !contaID.success) {
         throw new BadRequest();
       }
@@ -56,7 +54,7 @@ export const conta = {
         data: body.data,
       });
       res.status(200).json(contaAtualizada);
-    } catch (error: any) {
+    } catch (error: unknown) {
       throw error;
     }
   },
@@ -65,7 +63,7 @@ export const conta = {
       const contasEncontradas = await contaFinanceira.findAll();
 
       res.json(contasEncontradas);
-    } catch (error: any) {
+    } catch (error: unknown) {
       throw error;
     }
   },
@@ -87,7 +85,6 @@ export const conta = {
   DELETE: async (req: ExtendedRequest, res: Response) => {
     try {
       const id = z.coerce.number().positive().safeParse(req.params.id);
-      console.log(id);
       if (!id.success) {
         throw new BadRequest();
       }
@@ -112,7 +109,6 @@ export const transferencia = {
         })
         .safeParse(req.body);
 
-      console.log(data.error);
       if (!data.success) {
         throw new BadRequest();
       }
@@ -131,39 +127,27 @@ export const transferencia = {
   },
   GET: async (req: ExtendedRequest, res: Response) => {
     try {
-      const dataInicial = z
-
-        .string()
-
-        .regex(/^\d{4}-\d{2}-\d{2}$/, {
-          message: "dataInicial deve estar no formato YYYY-MM-DD",
+      const query = z
+        .object({
+          dataInicial: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional(),
+          dataFinal: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional(),
         })
+        .strict()
+        .refine(
+          ({ dataInicial, dataFinal }) =>
+            !dataInicial || !dataFinal || dataInicial <= dataFinal,
+        )
+        .safeParse(req.query);
 
-        .optional()
-        .safeParse(req.query.dataInicial);
-      const dataFinal = z
-
-        .string()
-
-        .regex(/^\d{4}-\d{2}-\d{2}$/, {
-          message: "dataInicial deve estar no formato YYYY-MM-DD",
-        })
-
-        .optional()
-        .safeParse(req.query.dataFinal);
-
-      if (!dataFinal.success || !dataInicial.success) {
-        console.log(dataFinal.error, dataInicial.error);
+      if (!query.success) {
         throw new BadRequest();
       }
       if (!req.user?.id) {
         throw new UnAuthorized();
       }
-      console.log(dataInicial, dataFinal);
-
       const transferenciasEncontradas = await transferenciaFinanceira.findAll({
-        dataFinal: dataFinal.data,
-        dataInicial: dataInicial.data,
+        dataFinal: query.data.dataFinal,
+        dataInicial: query.data.dataInicial,
       });
 
       res.status(200).json(transferenciasEncontradas);
@@ -208,7 +192,6 @@ export const transferencia = {
         id: id.data,
         user_id: req.user?.id,
       });
-      console.log(transferenciaEstornada);
       res.status(201).json(transferenciaEstornada);
     } catch (error) {
       throw error;

--- a/src/model/caixa.ts
+++ b/src/model/caixa.ts
@@ -211,7 +211,9 @@ const getByID = async (id: number) => {
       conta: { select: { id: true, nome: true } },
       usuario_abertura: { select: { id: true, nome: true } },
       usuario_fechamento: { select: { id: true, nome: true } },
-      movimentacoes: { orderBy: { id: "asc" } },
+      movimentacoes: {
+        orderBy: { id: "asc" },
+      },
     },
   });
 
@@ -231,12 +233,14 @@ const getByID = async (id: number) => {
         ? null
         : Number(caixa.saldo_final_informado),
     diferenca: caixa.diferenca === null ? null : Number(caixa.diferenca),
-    movimentacoes: caixa.movimentacoes.map((movimentacao) => ({
-      ...movimentacao,
-      saldo_inicial: Number(movimentacao.saldo_inicial),
-      valor: Number(movimentacao.valor),
-      saldo_final: Number(movimentacao.saldo_final),
-    })),
+    movimentacoes: caixa.movimentacoes
+      .filter((movimentacao) => movimentacao.conta_id === caixa.conta_id)
+      .map((movimentacao) => ({
+        ...movimentacao,
+        saldo_inicial: Number(movimentacao.saldo_inicial),
+        valor: Number(movimentacao.valor),
+        saldo_final: Number(movimentacao.saldo_final),
+      })),
   };
 };
 

--- a/src/model/contaFinanceira.ts
+++ b/src/model/contaFinanceira.ts
@@ -1,3 +1,4 @@
+import { Prisma } from "../../generated/prisma/client";
 import { ConflictError, NotFound } from "../error";
 import { prisma } from "../libs/prisma";
 
@@ -21,146 +22,136 @@ const create = async ({
   saldo_inicial,
   status,
 }: ContaInput) => {
-  try {
-    if (conta_padrao) {
-      const padraoExist = await prisma.contaFinanceira.findFirst({
-        where: {
-          conta_padrao: true,
+  const novaConta = await prisma.$transaction(
+    async (trx) => {
+      if (conta_padrao) {
+        const padraoExist = await trx.contaFinanceira.findFirst({
+          where: { conta_padrao: true },
+        });
+        if (padraoExist) {
+          throw new ConflictError(
+            "Não é possivel criar a conta. Já existe uma conta padrão definida.",
+          );
+        }
+      }
+
+      return trx.contaFinanceira.create({
+        data: {
+          nome,
+          saldo_inicial,
+          conta_padrao: conta_padrao ?? false,
+          saldo_atual: saldo_inicial,
+          status: status ?? true,
         },
       });
-      if (padraoExist?.id) {
-        throw new ConflictError(
-          "Não é possivel criar a conta. Já existe uma conta padrão definida.",
-        );
-      }
-    }
+    },
+    { isolationLevel: Prisma.TransactionIsolationLevel.Serializable },
+  );
 
-    const novaConta = await prisma.contaFinanceira.create({
-      data: {
-        nome,
-        saldo_inicial,
-        conta_padrao: conta_padrao || undefined,
-        saldo_atual: saldo_inicial,
-        status: status || undefined,
-      },
-    });
-    return {
-      ...novaConta,
-      saldo_inicial: Number(novaConta.saldo_inicial),
-      saldo_atual: Number(novaConta.saldo_atual),
-    };
-  } catch (error) {
-    throw error;
-  }
+  return {
+    ...novaConta,
+    saldo_inicial: Number(novaConta.saldo_inicial),
+    saldo_atual: Number(novaConta.saldo_atual),
+  };
 };
 const update = async ({ id, data }: EditContaInput) => {
-  try {
-    console.log(data);
-    const contaExist = await prisma.contaFinanceira.findFirst({
-      where: { id },
-    });
+  const contaAtualizada = await prisma.$transaction(
+    async (trx) => {
+      const contaExist = await trx.contaFinanceira.findUnique({ where: { id } });
+      if (!contaExist) {
+        throw new NotFound();
+      }
 
-    if (!contaExist?.id) {
-      throw new NotFound();
-    }
-    if (data.conta_padrao) {
-      const padraoExist = await prisma.contaFinanceira.findFirst({
-        where: {
-          conta_padrao: true,
-          NOT: {
-            id,
-          },
+      if (data.conta_padrao === true) {
+        const padraoExist = await trx.contaFinanceira.findFirst({
+          where: { conta_padrao: true, NOT: { id } },
+        });
+        if (padraoExist) {
+          throw new ConflictError(
+            "Não é possivel editar a conta. Já existe uma conta padrão definida.",
+          );
+        }
+      }
+
+      if (
+        contaExist.conta_padrao &&
+        (data.conta_padrao === false || data.status === false)
+      ) {
+        const caixaAberto = await trx.caixa.findFirst({
+          where: { conta_id: id, status: "ABERTO" },
+          select: { id: true },
+        });
+        if (caixaAberto) {
+          throw new ConflictError(
+            "A conta padrão não pode ser alterada enquanto houver caixa aberto.",
+          );
+        }
+      }
+
+      return trx.contaFinanceira.update({
+        where: { id },
+        data: {
+          nome: data.nome,
+          conta_padrao: data.conta_padrao,
+          status: data.status,
         },
       });
-      throw new ConflictError(
-        "Não é possivel editar a conta. Já existe uma conta padrão definida.",
-      );
-    }
-    const contaAtualizada = await prisma.contaFinanceira.update({
-      where: {
-        id,
-      },
-      data: {
-        nome: data.nome || undefined,
-        conta_padrao: data.conta_padrao ?? undefined,
-        status: data.status ?? undefined,
-      },
-    });
+    },
+    { isolationLevel: Prisma.TransactionIsolationLevel.Serializable },
+  );
 
-    return {
-      ...contaAtualizada,
-      saldo_inicial: Number(contaExist.saldo_inicial),
-      saldo_atual: Number(contaExist.saldo_atual),
-    };
-  } catch (error) {
-    throw error;
-  }
+  return {
+    ...contaAtualizada,
+    saldo_inicial: Number(contaAtualizada.saldo_inicial),
+    saldo_atual: Number(contaAtualizada.saldo_atual),
+  };
 };
 const deleteUnique = async (id: number) => {
-  try {
-    const contaExist = await prisma.contaFinanceira.findFirst({
-      where: { id },
-    });
+  const contaExist = await prisma.contaFinanceira.findUnique({
+    where: { id },
+  });
 
-    if (!contaExist?.id) {
-      throw new NotFound();
-    }
-
-    const padraoExist = await prisma.contaFinanceira.findFirst({
-      where: {
-        conta_padrao: true,
-      },
-    });
-    if (padraoExist?.id === id) {
-      throw new ConflictError(
-        "Não é possivel criar a conta. Já existe uma conta padrão definida.",
-      );
-    }
-    const contaDeletada = await prisma.contaFinanceira.update({
-      where: { id },
-      data: {
-        status: false,
-      },
-    });
-    return {
-      id: contaDeletada.id,
-      status: contaDeletada.status,
-    };
-  } catch (error) {
-    throw error;
+  if (!contaExist) {
+    throw new NotFound();
   }
+
+  if (contaExist.conta_padrao) {
+    throw new ConflictError("Não é possível desativar a conta padrão.");
+  }
+  const contaDeletada = await prisma.contaFinanceira.update({
+    where: { id },
+    data: {
+      status: false,
+    },
+  });
+  return {
+    id: contaDeletada.id,
+    status: contaDeletada.status,
+  };
 };
 const getByID = async (id: number) => {
-  try {
-    const contaExist = await prisma.contaFinanceira.findFirst({
-      where: { id },
-    });
+  const contaExist = await prisma.contaFinanceira.findUnique({
+    where: { id },
+  });
 
-    if (!contaExist?.id) {
-      throw new NotFound();
-    }
-
-    return {
-      ...contaExist,
-      saldo_inicial: Number(contaExist.saldo_inicial),
-      saldo_atual: Number(contaExist.saldo_atual),
-    };
-  } catch (error) {
-    throw error;
+  if (!contaExist) {
+    throw new NotFound();
   }
+
+  return {
+    ...contaExist,
+    saldo_inicial: Number(contaExist.saldo_inicial),
+    saldo_atual: Number(contaExist.saldo_atual),
+  };
 };
 const findAll = async () => {
-  try {
-    const contasEncontradas = await prisma.contaFinanceira.findMany();
+  const contasEncontradas = await prisma.contaFinanceira.findMany();
 
-    return contasEncontradas.map((conta) => ({
-      ...conta,
-      saldo_atual: Number(conta.saldo_atual),
-      saldo_inicial: Number(conta.saldo_inicial),
-    }));
-  } catch (error) {
-    throw error;
-  }
+  return contasEncontradas.map((conta) => ({
+    ...conta,
+    saldo_atual: Number(conta.saldo_atual),
+    saldo_inicial: Number(conta.saldo_inicial),
+  }));
 };
 
 const contaFinanceira = {

--- a/src/model/transferencia.ts
+++ b/src/model/transferencia.ts
@@ -1,15 +1,5 @@
-import {
-  BadRequest,
-  ConflictError,
-  InternalError,
-  NotFound,
-  NotPossible,
-} from "../error";
-import {
-  DirecaoFinanceira,
-  OrigemMovimentacao,
-  Prisma,
-} from "../../generated/prisma/client";
+import { Prisma } from "../../generated/prisma/client";
+import { ConflictError, NotFound } from "../error";
 import { prisma } from "../libs/prisma";
 
 export type TransferenciaInput = {
@@ -19,10 +9,46 @@ export type TransferenciaInput = {
   user_id: number;
   descricao?: string;
 };
+
 export type EstornoTransferenciaInput = {
   id: number;
   motivo: string;
   user_id: number;
+};
+
+type FindAllTransferenciasInput = {
+  dataInicial?: string;
+  dataFinal?: string;
+};
+
+const serializarMovimentacao = <T extends {
+  saldo_inicial: Prisma.Decimal;
+  valor: Prisma.Decimal;
+  saldo_final: Prisma.Decimal;
+}>(movimentacao: T) => ({
+  ...movimentacao,
+  saldo_inicial: movimentacao.saldo_inicial.toNumber(),
+  valor: movimentacao.valor.toNumber(),
+  saldo_final: movimentacao.saldo_final.toNumber(),
+});
+
+const caixaDaContaPadrao = async (
+  trx: Prisma.TransactionClient,
+  contas: Array<{ id: number; conta_padrao: boolean }>,
+) => {
+  const contaPadrao = contas.find((conta) => conta.conta_padrao);
+  if (!contaPadrao) return null;
+
+  const caixa = await trx.caixa.findFirst({
+    where: { conta_id: contaPadrao.id, status: "ABERTO" },
+    orderBy: { id: "desc" },
+  });
+  if (!caixa) {
+    throw new ConflictError(
+      "A conta padrão não pode ser movimentada sem um caixa aberto.",
+    );
+  }
+  return caixa;
 };
 
 const create = async ({
@@ -37,67 +63,56 @@ const create = async ({
       "A conta de origem e a conta de destino devem ser diferentes.",
     );
   }
-
   if (valor <= 0) {
     throw new ConflictError(
       "O valor da transferência deve ser maior que zero.",
     );
   }
 
-  try {
-    return await prisma.$transaction(async (trx) => {
-      const contaOrigemAtual = await trx.contaFinanceira.findUnique({
-        where: {
-          id: conta_origem_id,
-        },
-      });
-
-      const contaDestinoAtual = await trx.contaFinanceira.findUnique({
-        where: {
-          id: conta_destino_id,
-        },
-      });
+  return prisma.$transaction(
+    async (trx) => {
+      const [contaOrigemAtual, contaDestinoAtual] = await Promise.all([
+        trx.contaFinanceira.findUnique({ where: { id: conta_origem_id } }),
+        trx.contaFinanceira.findUnique({ where: { id: conta_destino_id } }),
+      ]);
 
       if (!contaOrigemAtual || !contaDestinoAtual) {
         throw new NotFound("A conta selecionada não foi encontrada.");
       }
+      if (!contaOrigemAtual.status || !contaDestinoAtual.status) {
+        throw new ConflictError(
+          "Não é possível transferir valores utilizando uma conta inativa.",
+        );
+      }
 
+      const caixa = await caixaDaContaPadrao(trx, [
+        contaOrigemAtual,
+        contaDestinoAtual,
+      ]);
       const contaOrigem = await trx.contaFinanceira.update({
-        where: {
-          id: conta_origem_id,
-        },
-        data: {
-          saldo_atual: { decrement: valor },
-        },
+        where: { id: conta_origem_id },
+        data: { saldo_atual: { decrement: valor } },
       });
       const contaDestino = await trx.contaFinanceira.update({
-        where: {
-          id: conta_destino_id,
-        },
-        data: {
-          saldo_atual: { increment: valor },
-        },
+        where: { id: conta_destino_id },
+        data: { saldo_atual: { increment: valor } },
       });
-
-      const caixaAberto = await trx.caixa.findFirst({
-        where: {
-          status: "ABERTO",
-          conta_id: { in: [conta_destino_id, conta_origem_id] },
-        },
-      });
-      let caixa_id = caixaAberto?.id;
+      const caixaOrigemId = contaOrigemAtual.conta_padrao ? caixa?.id : null;
+      const caixaDestinoId = contaDestinoAtual.conta_padrao ? caixa?.id : null;
+      const descricaoNormalizada = descricao?.trim();
 
       const novaTransferencia = await trx.transferenciaFinanceira.create({
         data: {
           conta_origem_id,
           conta_destino_id,
           valor,
-          descricao: `de ID ${conta_origem_id} P/ ID ${conta_destino_id} - ${descricao}`,
+          descricao: `de ID ${conta_origem_id} P/ ID ${conta_destino_id}${
+            descricaoNormalizada ? ` - ${descricaoNormalizada}` : ""
+          }`,
           user_id,
-          caixa_id,
+          caixa_id: caixa?.id,
           movimentacoes: {
             create: [
-              //ORIGEM
               {
                 conta_id: conta_origem_id,
                 direcao: "SAIDA",
@@ -106,7 +121,7 @@ const create = async ({
                 saldo_inicial: contaOrigemAtual.saldo_atual,
                 saldo_final: contaOrigem.saldo_atual,
                 valor,
-                caixa_id,
+                caixa_id: caixaOrigemId,
                 user_id,
               },
               {
@@ -117,7 +132,7 @@ const create = async ({
                 saldo_inicial: contaDestinoAtual.saldo_atual,
                 saldo_final: contaDestino.saldo_atual,
                 valor,
-                caixa_id,
+                caixa_id: caixaDestinoId,
                 user_id,
               },
             ],
@@ -125,117 +140,87 @@ const create = async ({
         },
         include: { movimentacoes: true },
       });
+
       return {
-        id: novaTransferencia.id,
-        conta_origem_id,
-        conta_destino_id,
-        valor: Number(novaTransferencia.valor),
-        descricao: novaTransferencia.descricao,
-        criado_em: novaTransferencia.criado_em,
-        user_id,
-        caixa_id: novaTransferencia.caixa_id,
-        movimentacoes: novaTransferencia.movimentacoes.map((mov) => ({
-          ...mov,
-          saldo_final: Number(mov.saldo_final),
-          saldo_inicial: Number(mov.saldo_inicial),
-          valor: Number(mov.valor),
-        })),
+        ...novaTransferencia,
+        valor: novaTransferencia.valor.toNumber(),
+        movimentacoes: novaTransferencia.movimentacoes.map(
+          serializarMovimentacao,
+        ),
       };
-    });
-  } catch (error) {
-    throw error;
-  }
+    },
+    { isolationLevel: Prisma.TransactionIsolationLevel.Serializable },
+  );
 };
+
 const reverse = async ({ id, motivo, user_id }: EstornoTransferenciaInput) => {
-  try {
-    if (!motivo.trim()) {
-      throw new ConflictError("O motivo do estorno deve ser informado.");
-    }
-    return prisma.$transaction(async (trx) => {
+  if (!motivo.trim()) {
+    throw new ConflictError("O motivo do estorno deve ser informado.");
+  }
+
+  return prisma.$transaction(
+    async (trx) => {
       const transferenciaOriginal =
         await trx.transferenciaFinanceira.findUnique({
-          where: {
-            id,
-          },
-          include: {
-            movimentacoes: true,
-          },
+          where: { id },
+          include: { movimentacoes: true },
         });
       if (!transferenciaOriginal) {
         throw new NotFound("Transferência não encontrada.");
       }
-
       if (transferenciaOriginal.estorno_de_id) {
         throw new ConflictError(
           "Uma transferência de estorno não pode ser estornada diretamente.",
         );
       }
-
       if (transferenciaOriginal.estornada) {
         throw new ConflictError("Esta transferência já foi estornada.");
       }
 
-      const contaOrigemEstorno = await trx.contaFinanceira.findUnique({
-        where: {
-          id: transferenciaOriginal.conta_destino_id,
-        },
-      });
-      const contaDestinoEstorno = await trx.contaFinanceira.findUnique({
-        where: {
-          id: transferenciaOriginal.conta_origem_id,
-        },
-      });
-
+      const [contaOrigemEstorno, contaDestinoEstorno] = await Promise.all([
+        trx.contaFinanceira.findUnique({
+          where: { id: transferenciaOriginal.conta_destino_id },
+        }),
+        trx.contaFinanceira.findUnique({
+          where: { id: transferenciaOriginal.conta_origem_id },
+        }),
+      ]);
       if (!contaOrigemEstorno || !contaDestinoEstorno) {
         throw new NotFound(
           "Uma das contas vinculadas à transferência não foi encontrada.",
         );
       }
+      if (!contaOrigemEstorno.status || !contaDestinoEstorno.status) {
+        throw new ConflictError(
+          "Não é possível estornar a transferência utilizando uma conta inativa.",
+        );
+      }
+
+      const caixa = await caixaDaContaPadrao(trx, [
+        contaOrigemEstorno,
+        contaDestinoEstorno,
+      ]);
       const valor = transferenciaOriginal.valor;
-
       const contaOrigemAtualizada = await trx.contaFinanceira.update({
-        where: {
-          id: contaOrigemEstorno.id,
-        },
-
-        data: {
-          saldo_atual: {
-            decrement: valor,
-          },
-        },
+        where: { id: contaOrigemEstorno.id },
+        data: { saldo_atual: { decrement: valor } },
       });
-
       const contaDestinoAtualizada = await trx.contaFinanceira.update({
-        where: {
-          id: contaDestinoEstorno.id,
-        },
-
-        data: {
-          saldo_atual: {
-            increment: valor,
-          },
-        },
+        where: { id: contaDestinoEstorno.id },
+        data: { saldo_atual: { increment: valor } },
       });
-
-      const caixaAberto = await trx.caixa.findFirst({
-        where: {
-          status: "ABERTO",
-          conta_id: {
-            in: [contaOrigemAtualizada.id, contaDestinoAtualizada.id],
-          },
-        },
-      });
-      let caixa_id = caixaAberto?.id;
+      const caixaOrigemId = contaOrigemEstorno.conta_padrao ? caixa?.id : null;
+      const caixaDestinoId = contaDestinoEstorno.conta_padrao ? caixa?.id : null;
 
       const transferenciaEstorno = await trx.transferenciaFinanceira.create({
         data: {
           conta_origem_id: contaOrigemEstorno.id,
           conta_destino_id: contaDestinoEstorno.id,
           valor,
-          descricao: `Estorno da transferência #${transferenciaOriginal.id}: ${motivo}`,
+          descricao: `Estorno da transferência #${transferenciaOriginal.id}: ${motivo.trim()}`,
           user_id,
           estorno_de_id: transferenciaOriginal.id,
-          caixa_id,
+          caixa_id: caixa?.id,
           movimentacoes: {
             create: [
               {
@@ -246,7 +231,7 @@ const reverse = async ({ id, motivo, user_id }: EstornoTransferenciaInput) => {
                 valor,
                 saldo_inicial: contaOrigemEstorno.saldo_atual,
                 saldo_final: contaOrigemAtualizada.saldo_atual,
-                caixa_id,
+                caixa_id: caixaOrigemId,
                 user_id,
               },
               {
@@ -257,16 +242,13 @@ const reverse = async ({ id, motivo, user_id }: EstornoTransferenciaInput) => {
                 valor,
                 saldo_inicial: contaDestinoEstorno.saldo_atual,
                 saldo_final: contaDestinoAtualizada.saldo_atual,
-                caixa_id,
+                caixa_id: caixaDestinoId,
                 user_id,
               },
             ],
           },
         },
-
-        include: {
-          movimentacoes: true,
-        },
+        include: { movimentacoes: true },
       });
 
       await trx.transferenciaFinanceira.update({
@@ -274,92 +256,67 @@ const reverse = async ({ id, motivo, user_id }: EstornoTransferenciaInput) => {
         data: {
           estornada: true,
           movimentacoes: {
-            updateMany: [
-              {
-                where: { origem: "TRANSFERENCIA" },
-                data: {
-                  estornada: true,
-                },
-              },
-            ],
+            updateMany: {
+              where: { origem: "TRANSFERENCIA" },
+              data: { estornada: true },
+            },
           },
         },
       });
-      return {
-        id: transferenciaEstorno.id,
-        conta_origem_id: contaOrigemAtualizada.id,
-        conta_destino_id: contaDestinoAtualizada.id,
-        valor: Number(transferenciaEstorno.valor),
-        descricao: transferenciaEstorno.descricao,
-        criado_em: transferenciaEstorno.criado_em,
-        user_id,
-        caixa_id: transferenciaEstorno.caixa_id,
-        movimentacoes: transferenciaEstorno.movimentacoes.map((mov) => ({
-          ...mov,
-          saldo_final: Number(mov.saldo_final),
-          saldo_inicial: Number(mov.saldo_inicial),
-          valor: Number(mov.valor),
-        })),
-      };
-    });
-  } catch (error) {
-    throw error;
-  }
-};
 
-type FindAllTransferenciasInput = {
-  dataInicial?: string;
-  dataFinal?: string;
+      return {
+        ...transferenciaEstorno,
+        valor: transferenciaEstorno.valor.toNumber(),
+        movimentacoes: transferenciaEstorno.movimentacoes.map(
+          serializarMovimentacao,
+        ),
+      };
+    },
+    { isolationLevel: Prisma.TransactionIsolationLevel.Serializable },
+  );
 };
 
 const findAll = async ({
   dataInicial,
   dataFinal,
 }: FindAllTransferenciasInput) => {
-  if (!dataFinal || !dataInicial) {
-    throw new InternalError();
-  }
-  const dataInicialParse = `${dataInicial}T00:00:00.000Z`;
-  const dataFinalParse = `${dataFinal}T23:59:59.999Z`;
-  console.log("DATAS", dataFinalParse, dataInicialParse);
-
   const transferencias = await prisma.transferenciaFinanceira.findMany({
     where: {
-      criado_em: {
-        gte: dataInicialParse,
-        lte: dataFinalParse,
-      },
+      criado_em:
+        dataInicial || dataFinal
+          ? {
+              gte: dataInicial
+                ? new Date(`${dataInicial}T00:00:00.000Z`)
+                : undefined,
+              lte: dataFinal
+                ? new Date(`${dataFinal}T23:59:59.999Z`)
+                : undefined,
+            }
+          : undefined,
     },
-
-    orderBy: {
-      criado_em: "desc",
-    },
+    orderBy: { criado_em: "desc" },
   });
 
-  return transferencias;
+  return transferencias.map((transferencia) => ({
+    ...transferencia,
+    valor: transferencia.valor.toNumber(),
+  }));
 };
+
 const getByID = async (id: number) => {
-  try {
-    const transfExist = await prisma.transferenciaFinanceira.findUnique({
-      where: { id },
-    });
-
-    if (!transfExist?.id) {
-      throw new NotFound();
-    }
-
-    return { ...transfExist, valor: Number(transfExist.valor) };
-  } catch (error) {
-    throw error;
+  const transferencia = await prisma.transferenciaFinanceira.findUnique({
+    where: { id },
+    include: { movimentacoes: { orderBy: { id: "asc" } } },
+  });
+  if (!transferencia) {
+    throw new NotFound();
   }
+
+  return {
+    ...transferencia,
+    valor: transferencia.valor.toNumber(),
+    movimentacoes: transferencia.movimentacoes.map(serializarMovimentacao),
+  };
 };
 
-const transferenciaFinanceira = {
-  create,
-  reverse,
-  findAll,
-  getByID,
-};
-
-export default transferenciaFinanceira;
-// parei aqui nas asteracoes feitas em tipomovimentacao
+export default { create, reverse, findAll, getByID };

--- a/src/routes/conta.ts
+++ b/src/routes/conta.ts
@@ -1,4 +1,4 @@
-import { Response, Router } from "express";
+import { Router } from "express";
 import { conta } from "../controllers/financeiro";
 import { AuthMiddleware } from "../controllers/middleware";
 import { authorize } from "../controllers/auth-middleware";
@@ -9,13 +9,11 @@ export const contaRoutes = Router();
 contaRoutes.get(
   "/contas",
   AuthMiddleware,
-  AuthMiddleware,
   authorize("read:contas"),
   conta.GET,
 );
 contaRoutes.patch(
   "/contas/:id",
-  AuthMiddleware,
   AuthMiddleware,
   authorize("update:conta"),
   conta.PATCH,
@@ -37,7 +35,6 @@ contaRoutes.post(
 
 contaRoutes.delete(
   "/contas/:id",
-  AuthMiddleware,
   AuthMiddleware,
   authorize("delete:conta"),
   conta.DELETE,

--- a/src/routes/transferenciaFin.ts
+++ b/src/routes/transferenciaFin.ts
@@ -1,4 +1,4 @@
-import { Response, Router } from "express";
+import { Router } from "express";
 import { transferencia } from "../controllers/financeiro";
 import { AuthMiddleware } from "../controllers/middleware";
 import { authorize } from "../controllers/auth-middleware";
@@ -9,13 +9,11 @@ export const finTransfRoutes = Router();
 finTransfRoutes.get(
   "/transferencia",
   AuthMiddleware,
-  AuthMiddleware,
   authorize("read:contas"),
   transferencia.GET,
 );
 finTransfRoutes.get(
   "/transferencia/:id",
-  AuthMiddleware,
   AuthMiddleware,
   authorize("read:contas"),
   transferencia.GET_UNIQUE,

--- a/src/tests/caixa/get.test.ts
+++ b/src/tests/caixa/get.test.ts
@@ -74,7 +74,8 @@ describe("consultas de caixa", () => {
       conta: { id: conta.id, nome: conta.nome },
       saldo_inicial: 1000,
     });
-    expect(response.body.movimentacoes).toHaveLength(2);
+    expect(response.body.movimentacoes).toHaveLength(1);
+    expect(response.body.movimentacoes[0].conta_id).toBe(conta.id);
     expect(
       response.body.movimentacoes.every(
         (movimentacao: { valor: unknown }) =>

--- a/src/tests/contas/[id]/patch.test.ts
+++ b/src/tests/contas/[id]/patch.test.ts
@@ -66,6 +66,46 @@ describe("PATCH /v1/financeiro/contas/[id]/", () => {
     });
   });
 
+  test("promove uma conta para padrão quando não existe outra padrão", async () => {
+    const user = await orchestrator.userAuthenticated({});
+    const conta = await orchestrator.createConta({
+      nome: "CONTA",
+      saldo_inicial: 0,
+      conta_padrao: false,
+    });
+
+    const response = await request(app)
+      .patch(`/v1/financeiro/contas/${conta.id}`)
+      .send({ conta_padrao: true })
+      .auth(user.jwt, { type: "bearer" })
+      .expect(200);
+
+    expect(response.body.conta_padrao).toBe(true);
+  });
+
+  test("não permite alterar a conta padrão com caixa aberto", async () => {
+    const user = await orchestrator.userAuthenticated({});
+    const conta = await orchestrator.createConta({
+      nome: "CONTA PADRAO",
+      saldo_inicial: 100,
+      conta_padrao: true,
+    });
+    await orchestrator.abrirCaixa({
+      user_id: user.id,
+      conta_id: conta.id,
+    });
+
+    const response = await request(app)
+      .patch(`/v1/financeiro/contas/${conta.id}`)
+      .send({ conta_padrao: false })
+      .auth(user.jwt, { type: "bearer" })
+      .expect(409);
+
+    expect(response.body.mensagem).toBe(
+      "A conta padrão não pode ser alterada enquanto houver caixa aberto.",
+    );
+  });
+
   test("Com id inválido", async () => {
     const user = await orchestrator.userAuthenticated({
       nome: "ADMINISTRADOR",

--- a/src/tests/orchestrator.ts
+++ b/src/tests/orchestrator.ts
@@ -215,7 +215,7 @@ const createConta = async (Props: {
     nome: Props.nome,
     saldo_inicial: Props.saldo_inicial,
     conta_padrao: Props.conta_padrao,
-    status: Props.status || undefined,
+    status: Props.status ?? undefined,
   });
 };
 

--- a/src/tests/transferencias/post.test.ts
+++ b/src/tests/transferencias/post.test.ts
@@ -53,6 +53,101 @@ describe("POST /v1/financeiro/transferencia", () => {
     expect(response.body.movimentacoes[0].saldo_final).toBe(50);
     expect(response.body.movimentacoes[1].saldo_final).toBe(150);
   });
+  test("Bloqueia transferência da conta padrão sem caixa aberto", async () => {
+    const user = await orchestrator.userAuthenticated({});
+    const contaPadrao = await orchestrator.createConta({
+      nome: "CONTA PADRAO",
+      conta_padrao: true,
+      saldo_inicial: 100,
+    });
+    const destino = await orchestrator.createConta({
+      nome: "CONTA DESTINO",
+      conta_padrao: false,
+      saldo_inicial: 100,
+    });
+
+    const response = await request(app)
+      .post("/v1/financeiro/transferencia")
+      .send({
+        valor: 50,
+        conta_origem_id: contaPadrao.id,
+        conta_destino_id: destino.id,
+      })
+      .auth(user.jwt, { type: "bearer" })
+      .expect(409);
+
+    expect(response.body.mensagem).toBe(
+      "A conta padrão não pode ser movimentada sem um caixa aberto.",
+    );
+  });
+
+  test("Vincula ao caixa somente o movimento da conta padrão", async () => {
+    const user = await orchestrator.userAuthenticated({});
+    const contaPadrao = await orchestrator.createConta({
+      nome: "CONTA PADRAO",
+      conta_padrao: true,
+      saldo_inicial: 100,
+    });
+    const destino = await orchestrator.createConta({
+      nome: "CONTA DESTINO",
+      conta_padrao: false,
+      saldo_inicial: 100,
+    });
+    const caixa = await orchestrator.abrirCaixa({
+      user_id: user.id,
+      conta_id: contaPadrao.id,
+    });
+
+    const response = await request(app)
+      .post("/v1/financeiro/transferencia")
+      .send({
+        valor: 50,
+        conta_origem_id: contaPadrao.id,
+        conta_destino_id: destino.id,
+      })
+      .auth(user.jwt, { type: "bearer" })
+      .expect(201);
+
+    expect(response.body.caixa_id).toBe(caixa.id);
+    expect(response.body.movimentacoes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          conta_id: contaPadrao.id,
+          caixa_id: caixa.id,
+        }),
+        expect.objectContaining({ conta_id: destino.id, caixa_id: null }),
+      ]),
+    );
+  });
+
+  test("Bloqueia transferência com conta inativa", async () => {
+    const user = await orchestrator.userAuthenticated({});
+    const origem = await orchestrator.createConta({
+      nome: "CONTA INATIVA",
+      conta_padrao: false,
+      saldo_inicial: 100,
+      status: false,
+    });
+    const destino = await orchestrator.createConta({
+      nome: "CONTA ATIVA",
+      conta_padrao: false,
+      saldo_inicial: 100,
+    });
+
+    const response = await request(app)
+      .post("/v1/financeiro/transferencia")
+      .send({
+        valor: 50,
+        conta_origem_id: origem.id,
+        conta_destino_id: destino.id,
+      })
+      .auth(user.jwt, { type: "bearer" })
+      .expect(409);
+
+    expect(response.body.mensagem).toBe(
+      "Não é possível transferir valores utilizando uma conta inativa.",
+    );
+  });
   // test("Deve criar uma transferencia entre uma conta padrao e uma normal", async () => {
   //   const user = await orchestrator.userAuthenticated({
   //     nome: "ADMINISTRADOR",

--- a/src/tests/transferencias/post_estorno.test.ts
+++ b/src/tests/transferencias/post_estorno.test.ts
@@ -56,6 +56,44 @@ describe("POST /v1/financeiro/transferencia/estorno/${transferencia.id}", () => 
     expect(response.body.movimentacoes[0].saldo_final).toBe(100);
     expect(response.body.movimentacoes[1].saldo_final).toBe(100);
   });
+  test("Bloqueia estorno na conta padrão sem caixa aberto", async () => {
+    const user = await orchestrator.userAuthenticated({});
+    const contaPadrao = await orchestrator.createConta({
+      nome: "CONTA PADRAO",
+      conta_padrao: true,
+      saldo_inicial: 100,
+    });
+    const destino = await orchestrator.createConta({
+      nome: "CONTA DESTINO",
+      conta_padrao: false,
+      saldo_inicial: 100,
+    });
+    await orchestrator.abrirCaixa({
+      user_id: user.id,
+      conta_id: contaPadrao.id,
+    });
+    const transferencia = await orchestrator.createTransferencia({
+      valor: 50,
+      conta_origem_id: contaPadrao.id,
+      conta_destino_id: destino.id,
+      user_id: user.id,
+    });
+    await request(app)
+      .post("/v1/financeiro/caixa/fechar")
+      .send({ saldo_informado: 50 })
+      .auth(user.jwt, { type: "bearer" })
+      .expect(200);
+
+    const response = await request(app)
+      .post(`/v1/financeiro/transferencia/estorno/${transferencia.id}`)
+      .send({ motivo: "ESTORNO FORA DO CAIXA" })
+      .auth(user.jwt, { type: "bearer" })
+      .expect(409);
+
+    expect(response.body.mensagem).toBe(
+      "A conta padrão não pode ser movimentada sem um caixa aberto.",
+    );
+  });
   // test("Deve criar um estorno de uma conta com caixa aberto", async () => {
   //   const user = await orchestrator.userAuthenticated({
   //     nome: "ADMINISTRADOR",


### PR DESCRIPTION
## O que mudou

- corrige criação e promoção da conta financeira padrão;
- preserva valores booleanos explícitos, inclusive contas inativas;
- protege alterações da conta padrão enquanto existe caixa aberto;
- exige caixa aberto em transferências e estornos envolvendo a conta padrão;
- impede transferências e estornos com contas inativas;
- vincula ao caixa somente a movimentação pertencente à conta padrão;
- aplica isolamento serializável às operações críticas;
- normaliza valores monetários das transferências como números;
- corrige filtros de data e detalhe de transferências;
- impede que o detalhe do caixa misture movimentos de outras contas;
- adiciona testes de regressão para os fluxos corrigidos.

## Por que

O fluxo anterior permitia alterar o saldo da conta padrão sem caixa aberto, misturava movimentações de contas externas no detalhe do caixa e impedia a promoção válida de uma nova conta padrão. Esses comportamentos quebravam a reconciliação financeira exigida para o MVP.

## Impacto

Os endpoints e o schema Prisma permanecem inalterados. Operações que já contrariavam as regras financeiras passam a retornar conflito sem modificar saldos.

## Validação

- `prisma validate`: passou;
- `git diff --check`: passou;
- o código alterado não adicionou erros de TypeScript;
